### PR TITLE
Fix mismatch in acquire_neon_data argument naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To analyze fluxes once the package is installed requires a two step process:
 ` acquire_neon_data(site_name ="SJER",
                   start_date = "2020-06",
                   end_date = "2020-06",
-                  file_name = "my-file-2020-06.Rda") `
+                  data_file_name = "my-file-2020-06.Rda") `
 
 2. Then process and compute fluxes.
 ` out_fluxes_jan <- compute_neon_flux("my-file-2020-06.Rda") `

--- a/process-files/01-acquire-data.R
+++ b/process-files/01-acquire-data.R
@@ -40,7 +40,7 @@ start_time <- Sys.time()
 acquire_neon_data(site_name =my_sites$sites[[1]],
                   start_date = my_sites$start_dates[[1]],
                   end_date = my_sites$end_dates[[1]],
-                  file_name = "data-neon/test.Rda")
+                  data_file_name = "data-neon/test.Rda")
 
 # Then process and compute the fluxes from that data file.
 out_fluxes <- compute_neon_flux("data-neon/test.Rda")
@@ -55,7 +55,7 @@ end_time <- Sys.time()
 acquire_neon_data(site_name ="SJER",
                   start_date = "2020-02",
                   end_date = "2020-02",
-                  file_name = "flux-jan-june/flux-feb.Rda")
+                  data_file_name = "flux-jan-june/flux-feb.Rda")
 
 # Then process and compute the fluxes from that data file.
 out_fluxes_feb <- compute_neon_flux("flux-jan-june/flux-feb.Rda")

--- a/process-files/data-process.R
+++ b/process-files/data-process.R
@@ -24,7 +24,7 @@ for(i in seq_along(site_date_combine)) {
   acquire_neon_data(site_name =curr_site,
                         start_date = curr_date,
                         end_date = curr_date,
-                        file_name = acquire_name,
+                        data_file_name = acquire_name,
                         env_file_name = env_name)
 
    # out_fluxes <- compute_neon_flux("data/curr-flux.Rda")

--- a/process-files/site-process.R
+++ b/process-files/site-process.R
@@ -58,7 +58,7 @@ try(
  { acquire_neon_data(site_name =curr_site_name,
                     start_date = curr_month,
                     end_date = curr_month,
-                    file_name = acquire_name,
+                    data_file_name = acquire_name,
                     env_file_name = env_name)
 
   # Then process and compute the fluxes from that data file.

--- a/process-files/sjer-process-rev.R
+++ b/process-files/sjer-process-rev.R
@@ -76,7 +76,7 @@ for(i in 14:length(dates)) {
   acquire_neon_data(site_name ="SJER",
                      start_date = curr_month,
                      end_date = curr_month,
-                     file_name = acquire_name,
+                     data_file_name = acquire_name,
                      env_file_name = env_name)
 
   # Then process and compute the fluxes from that data file.

--- a/process-files/sjer-process.R
+++ b/process-files/sjer-process.R
@@ -14,7 +14,7 @@ devtools::install_github("jmzobitz/NEONSoils", build = TRUE, build_opts = c("--n
 acquire_neon_data(site_name ="SJER",
                   start_date = "2020-05",
                   end_date = "2020-05",
-                  file_name = "process-files/my-file.Rda")
+                  data_file_name = "process-files/my-file.Rda")
 
 # Then process and compute the fluxes from that data file.
 out_fluxes <- compute_neon_flux("process-files/my-file.Rda")


### PR DESCRIPTION
The argument name in the function is data_file_name, but in several places it is called (or documented) as just file_name. This harmonizes uses to data_file_name.